### PR TITLE
Sensor integration

### DIFF
--- a/DroneFlightController/src/main.c
+++ b/DroneFlightController/src/main.c
@@ -103,7 +103,15 @@ void UART_Init(void) {
 // IMU sensor initialization
 void IMU_Init(void) {
     // Initialize and calibrate IMU sensor
-    // Implementation specific to IMU hardware
+    IMUSensor imu;
+    if (!imu.initialize()) {
+        logger_log(LOG_ERROR, __FILE__, __LINE__, "IMU initialization failed");
+        return;
+    }
+    if (!imu.calibrate()) {
+        logger_log(LOG_ERROR, __FILE__, __LINE__, "IMU calibration failed");
+        return;
+    }
 }
 
 // ESC initialization

--- a/DroneFlightController/src/sensors/imu_sensor.h
+++ b/DroneFlightController/src/sensors/imu_sensor.h
@@ -1,10 +1,3 @@
-//
-//  imu_sensor.h
-//  DroneFlightController
-//
-//  Created by Vishwanath Martur on 11/1/24.
-//
-
 #ifndef imu_sensor_h
 #define imu_sensor_h
 
@@ -37,6 +30,9 @@ public:
     bool isInitialized() const;
     bool isSelfTestPassed() const;
     
+    // Sensor register configuration
+    bool configureSensorRegisters();
+
 private:
     // Internal state
     bool initialized;


### PR DESCRIPTION
Related to #4

Add sensor register configuration and refine calibration routines for IMU initialization.

* **IMU Sensor Configuration:**
  - Add sensor register configuration in `initialize` function in `imu_sensor.c`.
  - Implement `configureSensorRegisters` function in `imu_sensor.c` to set sample rate, accelerometer, gyroscope configuration, and power management for MPU6050.
  - Add function prototype for `configureSensorRegisters` in `imu_sensor.h`.

* **IMU Initialization and Calibration:**
  - Refine IMU initialization in `IMU_Init` function in `main.c` to call `initialize` and `calibrate` methods of `IMUSensor`.
  - Add error logging for initialization and calibration failures in `IMU_Init` function in `main.c`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced IMU sensor initialization with improved error handling and logging.
	- Added a method for configuring sensor registers, ensuring proper setup before use.

- **Bug Fixes**
	- Improved robustness of sensor calibration and initialization processes.

- **Documentation**
	- Updated method documentation for new functionalities related to sensor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->